### PR TITLE
chore: use discord-typings pypi package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9"
 aiohttp = ">=3.6.0,<3.9.0"
-discord-typings = {git = "https://github.com/Bluenix2/discord-typings.git"}
+discord-typings = ">0.5.1"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/discatpy-dev/core/issues"


### PR DESCRIPTION
This PR updates `pyproject.toml` to use the discord-typings PyPi package. 

Stalled until next release of discord-typings. Stalls PyPi release of v0.1.0.